### PR TITLE
async keyword fixes inherited from bambou

### DIFF
--- a/vspk/v4_0/nume.py
+++ b/vspk/v4_0/nume.py
@@ -1029,8 +1029,8 @@ class NUMe(NURESTRootObject):
 
     
     ## Custom methods
-    def save(self, async=False, callback=None):
+    def save(self, isasync=False, callback=None):
         """ """
-        super(NUMe, self).save(async=async, callback=callback, encrypted=False)
+        super(NUMe, self).save(isasync=isasync, callback=callback, encrypted=False)
     
     

--- a/vspk/v5_0/nume.py
+++ b/vspk/v5_0/nume.py
@@ -1248,8 +1248,8 @@ class NUMe(NURESTRootObject):
 
     
     ## Custom methods
-    def save(self, async=False, callback=None):
+    def save(self, isasync=False, callback=None):
         """ """
-        super(NUMe, self).save(async=async, callback=callback, encrypted=False)
+        super(NUMe, self).save(isasync=isasync, callback=callback, encrypted=False)
     
     


### PR DESCRIPTION
These two changes are needed to fix vspk connection to bambou once they include the fixes for async keyword usage. In short, async became a keyword if python 3.7 and I did a pull request on bambou that changes the keyword "async" to the identifier "isasync". So that change needs also be done in vspk in the parameter calls for inherited class in nume.py . This would fix issue  #32 . 

However, to emphasize: for this fix to work first bambou has to accept their pull request, otherwise it would break vspk.